### PR TITLE
chore(deps): drop the unused uart_16550 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,12 +50,6 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -98,7 +92,7 @@ dependencies = [
 name = "cap"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "drivers",
  "klog",
  "mm",
@@ -208,7 +202,6 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "spin 0.9.9",
- "uart_16550 0.3.2",
  "x86_64",
 ]
 
@@ -285,7 +278,7 @@ dependencies = [
 name = "iommu"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "drivers",
  "klog",
  "mm",
@@ -338,7 +331,6 @@ dependencies = [
  "spin 0.12.3",
  "sync_safe",
  "trace",
- "uart_16550 0.6.0",
  "vfs",
  "x86_64",
 ]
@@ -348,7 +340,7 @@ name = "kernel_core"
 version = "0.1.0"
 dependencies = [
  "audit",
- "bitflags 2.13.0",
+ "bitflags",
  "cap",
  "compliance",
  "coverage",
@@ -472,7 +464,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -543,20 +535,11 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "raw-cpuid"
-version = "10.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -605,7 +588,7 @@ name = "seccomp"
 version = "0.1.0"
 dependencies = [
  "audit",
- "bitflags 2.13.0",
+ "bitflags",
  "drivers",
  "klog",
  "mm",
@@ -621,7 +604,7 @@ dependencies = [
  "klog",
  "lazy_static",
  "mm",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
  "spin 0.9.9",
  "x86_64",
 ]
@@ -720,26 +703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "uart_16550"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
-dependencies = [
- "bitflags 2.13.0",
- "rustversion",
- "x86",
-]
-
-[[package]]
-name = "uart_16550"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ee77075ecbc5e1c9b1236d03ff013dd77c7bb06da181c5c44f1f39b6cf3ff2"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
 name = "ucs2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +717,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e8fb42b46b5e5afaa49a237714d3259ccbf740ba68cbf25d715471b15cabe04"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "log",
  "ptr_meta",
@@ -781,7 +744,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a70d0f6b34cbeb4e5cd492b442bf9679a838fbb010551c4a3e3b9e25e316a8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "ptr_meta",
  "uguid",
 ]
@@ -808,7 +771,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vfs"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "block",
  "cap",
  "crypto",
@@ -835,24 +798,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
-name = "x86"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2781db97787217ad2a2845c396a5efe286f87467a5810836db6d74926e94a385"
-dependencies = [
- "bit_field",
- "bitflags 1.3.2",
- "raw-cpuid 10.7.0",
-]
-
-[[package]]
 name = "x86_64"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7841fa0098ceb15c567d93d3fae292c49e10a7662b4936d5f6a9728594555ba"
 dependencies = [
  "bit_field",
- "bitflags 2.13.0",
+ "bitflags",
  "const_fn",
  "rustversion",
  "volatile",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -37,7 +37,6 @@ host_harness = ["mm/host_harness", "kernel_core/host_harness"]
 spin = "0.12"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 x86_64 = "=0.15.4"
-uart_16550 = "0.6"
 linked_list_allocator = "0.10"
 arch = { path = "arch" }
 mm = { path = "mm" }

--- a/kernel/drivers/Cargo.toml
+++ b/kernel/drivers/Cargo.toml
@@ -9,5 +9,4 @@ path = "lib.rs"
 [dependencies]
 spin = "0.9"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
-uart_16550 = "0.3"
 x86_64 = "0.15"


### PR DESCRIPTION
## What

Removes `uart_16550` from both manifests that declare it:

- `kernel/Cargo.toml` (was `0.6`)
- `kernel/drivers/Cargo.toml` (was `0.3`)

## Why

No Rust source in the tree references `uart_16550` — the only occurrences anywhere are the two `Cargo.toml` declarations and stale build-artifact fingerprints. Serial output is hand-rolled raw port I/O against COM1 (`kernel/arch/interrupts.rs:45`, `SERIAL_PORT: u16 = 0x3F8`), so both declarations only pulled a second, unused UART implementation into the dependency graph.

Removing them also drops the transitive `bitflags 1.3.2` and `raw-cpuid 10.7.0` pins that only `uart_16550 0.3` required, which lets `Cargo.lock` collapse the duplicated `bitflags` / `raw-cpuid` entries back to single unambiguous names.

## Supersedes #24

Dependabot #24 raised the unused `kernel` dependency `0.6 -> 0.8` while leaving `kernel/drivers` on `0.3`. That would have kept **two** unused copies in the graph and Dependabot would keep re-proposing the same no-op bump. Deleting the dependency ends that loop.

`uart_16550 0.6 -> 0.8` also spans two breaking pre-1.0 releases, so #24 carried real API risk for zero benefit.

## Verification

Run on the Linux devbox against this branch:

| Gate | Result |
|---|---|
| `make fmt-check` | PASS |
| `make build` | PASS |
| `make clippy` | PASS |
| `make lint` | PASS |

`Cargo.lock` was regenerated on the devbox (not locally) so the committed lock is the authoritative one.