### PR TITLE
fix(net/test): make rf180_51 register its own TX device

### DIFF
--- a/kernel/net/src/stack.rs
+++ b/kernel/net/src/stack.rs
@@ -3878,7 +3878,23 @@ mod tests {
         let mut malformed_udp = valid_zero_udp;
         malformed_udp[5] = 0x09; // claims one byte beyond the immutable payload
 
-        firewall_remove_ns(DIRECT_NS);
+        // TEST-ISOLATION FIX: reaching policy evaluation requires a resolvable
+        // TX device, and hosted net tests register none by default. This oracle
+        // silently depended on a SIBLING test
+        // (`d1iso_resolver_gates_tx_by_namespace_ownership`) having registered
+        // "eth0" first; under default-parallel execution that ordering is not
+        // guaranteed, so the valid-datagram transmit below intermittently failed
+        // closed at the device gate with `LinkDown` instead of reaching the
+        // firewall. Register it here so the test is self-sufficient — the
+        // registry rejects duplicate names, so this is a no-op when a parallel
+        // test registered eth0 first, and every assert below is invariant to
+        // WHICH eth0 instance won.
+        let _ = crate::register_device(MockEthDevice);
+
+        // No ns-0 rule reset here on purpose: `firewall_remove_ns(0)` is a
+        // documented no-op (the root table is never removable), so a call would
+        // read as a reset while doing nothing. ns 0 keeps the pristine
+        // default-deny set for the whole process.
         assert_eq!(
             build_frame_and_transmit(Ipv4Proto::Udp, peer_ip, &malformed_udp, DIRECT_NS, None,),
             Err(TxError::InvalidBuffer),
@@ -3889,7 +3905,6 @@ mod tests {
             Err(TxError::FirewallDenied),
             "a structurally valid header-only datagram must reach default-deny"
         );
-        firewall_remove_ns(DIRECT_NS);
 
         firewall_remove_ns(REPLY_NS);
         firewall_table_for_ns(REPLY_NS).replace_rules(alloc::vec![FirewallRule::builder(51)


### PR DESCRIPTION
## Symptom

`stack::tests::rf180_51_malformed_transport_never_collapses_into_firewall_denial` fails intermittently in CI. It took down the `hosted kernel submodule tests` job on #28, whose diff touched only `.github/workflows/syzkaller-fuzz.yml` and therefore could not have caused it:

```
left: Err(LinkDown)
assertion `left == right` failed: a structurally valid header-only
datagram must reach default-deny
    kernel/net/src/stack.rs:3887
```

## Root cause

Reaching firewall policy evaluation requires a **resolvable TX device**, and hosted net tests register none by default. The test never registered one itself, so it silently depended on a *sibling* test — `d1iso_resolver_gates_tx_by_namespace_ownership` (`stack.rs:4186`) — having already called `register_device(MockEthDevice)`.

The hosted suite runs at Rust's default parallelism, so that ordering is not guaranteed. When `rf180_51` reaches the transmit first, it fails closed at the device gate with `LinkDown` instead of reaching the firewall and returning `FirewallDenied`.

This is an ordering dependency, not a data race, which is why it is rare but not load-dependent: 55 consecutive full-suite runs on the devbox (25 normal + 30 pinned to 2 cores) never reproduced it.

### Deterministic proof

Running the test **alone** removes every other device registrant and reproduces it 100% of the time:

```
$ cargo test -p net --lib -- stack::tests::rf180_51     # before this change
test stack::tests::rf180_51_... ... FAILED
  left: Err(LinkDown)

$ cargo test -p net --lib -- stack::tests::rf180_51     # after this change
test result: ok. 1 passed
```

## Fix

Register the device in the test itself. The registry rejects duplicate names, so this is a no-op when a parallel test registered `"eth0"` first, and every assertion is invariant to which instance won — the same idempotent pattern the sibling test already documents.

Also drops the two `firewall_remove_ns(DIRECT_NS)` calls. `DIRECT_NS` is `0`, and `firewall_remove_ns` returns early for the root namespace by design (`firewall.rs:721-724`), so both were **no-ops that read as a state reset while doing nothing** — which is what disguised the ambient-state dependency in the first place. A comment now records why no reset is performed.

## Verification (devbox)

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | PASS |
| `make clippy` | PASS |
| `make lint` | PASS (ABI-ORACLE: 11 structs, 100 values, 17 tripwires) |
| `make test-hosted-subcrates` | PASS — 239 tests, `net` still matches its 116-test count-pinned oracle |
| `rf180_51` standalone | PASS (was `LinkDown`) |
| 25 consecutive full-suite runs (15 normal + 10 pinned to 2 cores) | 0 failures |