### PR TITLE
chore(deps): bump fuzzer hmac to 0.13 and sha2 to 0.11 together

### DIFF
--- a/userspace/fuzzer/Cargo.lock
+++ b/userspace/fuzzer/Cargo.lock
@@ -54,11 +54,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -108,39 +108,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -154,16 +175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,11 +182,20 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -270,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -286,16 +306,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -319,12 +333,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-link"

--- a/userspace/fuzzer/Cargo.toml
+++ b/userspace/fuzzer/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/bin/crash-triage.rs"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 
 [dev-dependencies]
 serde_json = "1"

--- a/userspace/fuzzer/src/bin/crash-triage.rs
+++ b/userspace/fuzzer/src/bin/crash-triage.rs
@@ -6,7 +6,7 @@
 //! messages, paths, hashes, stack traces, or previews into its output directory.
 
 use clap::Parser;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 use std::collections::HashSet;
 use std::error::Error;
@@ -446,6 +446,28 @@ mod tests {
         ] {
             assert!(!report.contains(forbidden), "leaked field: {forbidden}");
         }
+    }
+
+    /// Absolute pin on the candidate-ID construction.
+    ///
+    /// The sibling test above asserts only RELATIVE properties (repeatable,
+    /// key-scoped, target-scoped, payload-scoped), and `assert_keyed_id_shape`
+    /// checks only the prefix plus 64 hex characters. Nothing pinned the actual
+    /// bytes, so a dependency bump or a reordering of the length-prefixed HMAC
+    /// fields could change every published candidate ID while the whole suite
+    /// stayed green. Candidate IDs are the cross-run dedup key for fuzz
+    /// findings, so they must stay byte-stable across dependency updates.
+    ///
+    /// Cross-checked under hmac 0.12/sha2 0.10 (digest 0.10) and hmac
+    /// 0.13/sha2 0.11 (digest 0.11): identical under both.
+    #[test]
+    fn candidate_id_matches_its_pinned_golden_vector() {
+        let id = keyed_candidate_id(TEST_KEY, "fuzz_syscall", "crash", &[0xde, 0xad, 0xbe, 0xef])
+            .expect("golden-vector candidate ID must be derivable");
+        assert_eq!(
+            id, "hmac-sha256:507b92507406a7382ec62cab4ba57429f8209c21d3284f677bc18b5fd6acc804",
+            "candidate-ID bytes changed: the fuzz dedup key is no longer stable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replaces #26 (`hmac` 0.12.1 → 0.13.0) and #27 (`sha2` 0.10.9 → 0.11.0), **neither of which can land on its own, and which do not work even when combined without a source change.**

## Why they are coupled

`crash-triage.rs` builds `Hmac<Sha256>`, so both crates must agree on the `digest` version. Each Dependabot PR bumps only one, leaving the lock with **both** `digest 0.10.7` and `digest 0.11.3` and the type unsatisfiable. Verified by building each on the devbox:

| Variant | Result |
|---|---|
| #26 alone (hmac 0.13, sha2 0.10) | ❌ `E0277: the trait bound CoreWrapper<CtVariableCoreWrapper<Sha256VarCore, ..>>: CoreProxy is not satisfied` |
| #27 alone (hmac 0.12, sha2 0.11) | ❌ `E0277: the trait bound Sha256: hmac::digest::core_api::CoreProxy is not satisfied` |
| Both, no source change | ❌ `E0599: no function 'new_from_slice' for Hmac<D>` |
| **Both + `KeyInit` import (this PR)** | ✅ builds, 26 tests pass |

`hmac` 0.13 moved `new_from_slice` off `Mac` and onto `KeyInit`, hence the one-line import widening at `crash-triage.rs:9`.

After this change `digest` resolves to a **single** version (0.11.3) rather than a duplicated tree.

## Why CI did not catch it

`fuzz.yml` is the only workflow that compiles `userspace/fuzzer`, and it triggers on `schedule` / `workflow_dispatch` / `push: main` — **never `pull_request`** (`.github/workflows/fuzz.yml:3-34`). `ci.yml` runs on PRs but does not touch that crate.

So #26 and #27 each reported **six green checks without ever building the crate they change**, and would have turned `main` red on merge. Worth fixing separately — either give `fuzz-tools-test` a `pull_request` trigger, or group coupled RustCrypto crates in `dependabot.yml` (they arrived split because Dependabot treats `0.x` leading-zero bumps as *major*, and `fuzzer-tools-minor-and-patch` groups only minor+patch).

## Golden vector

This PR also pins the candidate-ID construction with an absolute test vector.

`candidate_ids_are_keyed_stable_and_target_scoped` asserts only **relative** properties (repeatable, key-scoped, target-scoped, payload-scoped), and `assert_keyed_id_shape` checks only the `hmac-sha256:` prefix plus 64 hex characters. Nothing pinned the actual bytes — so a dependency bump could have changed every published candidate ID with the whole suite still green. Candidate IDs are the cross-run dedup key for fuzz findings, so that would silently fragment crash identity.

The vector passes **unchanged under both** `hmac 0.12`/`sha2 0.10` and `hmac 0.13`/`sha2 0.11`. That is what establishes this bump is value-preserving, and it was independently cross-checked against RFC 4231 test case 2 under both dependency sets.

## Verification (devbox)

| Gate | Result |
|---|---|
| `cargo test --all-targets` | PASS — 26 tests |
| golden vector under **old** deps | PASS |
| golden vector under **new** deps | PASS (identical value) |
| `cargo clippy -D warnings` | PASS |
| `cargo fmt --check` (this file) | PASS |

> Note: `cargo fmt --check` reports a pre-existing diff in `userspace/fuzzer/crash_triage.rs`, untouched by this PR. `userspace/fuzzer` is a separate workspace and `fuzz.yml` never runs a formatting gate on it, so that drift is unrelated and left alone.